### PR TITLE
Add tests for createChildCategory service method

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node src/index.js",
     "migrate": "sequelize db:migrate",
-    "seed": "sequelize db:seed:all"
+    "seed": "sequelize db:seed:all",
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/test/services/category.service.test.js
+++ b/test/services/category.service.test.js
@@ -1,0 +1,49 @@
+const { test, beforeEach, after } = require('node:test');
+const assert = require('node:assert');
+const { Sequelize, DataTypes } = require('sequelize');
+
+// Set up in-memory SQLite database and load Category model
+const sequelize = new Sequelize('sqlite::memory:', { logging: false });
+const Category = require('../../src/models/product/category.model')(sequelize, DataTypes);
+const db = { sequelize, Sequelize, Category };
+
+// Mock the models module used by the service
+require.cache[require.resolve('../../src/models')] = { exports: db };
+const CategoryService = require('../../src/services/category.service');
+
+beforeEach(async () => {
+  await sequelize.sync({ force: true });
+});
+
+after(async () => {
+  await sequelize.close();
+});
+
+test('createChildCategory increments existing categories\' lft/rgt correctly', async () => {
+  const root1 = await CategoryService.createRootCategory({ name: 'root1', handle: 'root1' });
+  const root2 = await CategoryService.createRootCategory({ name: 'root2', handle: 'root2' });
+
+  assert.strictEqual(root1.lft, 1);
+  assert.strictEqual(root1.rgt, 2);
+  assert.strictEqual(root2.lft, 3);
+  assert.strictEqual(root2.rgt, 4);
+
+  const child = await CategoryService.createChildCategory(root1.id, { name: 'child', handle: 'child' });
+
+  await root1.reload();
+  await root2.reload();
+
+  assert.strictEqual(root1.lft, 1);
+  assert.strictEqual(root1.rgt, 4);
+  assert.strictEqual(child.lft, 2);
+  assert.strictEqual(child.rgt, 3);
+  assert.strictEqual(root2.lft, 5);
+  assert.strictEqual(root2.rgt, 6);
+});
+
+test('createChildCategory throws error when parentId is invalid', async () => {
+  await assert.rejects(
+    CategoryService.createChildCategory('bad-id', { name: 'child', handle: 'child' }),
+    /Parent category not found/
+  );
+});


### PR DESCRIPTION
## Summary
- add npm script to run node's built-in test runner
- test CategoryService.createChildCategory updates lft/rgt and handles invalid parent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abe09247f4832aa2a54509f59eb0ae