### PR TITLE
Add cart checkout endpoint

### DIFF
--- a/src/controllers/cart.controller.js
+++ b/src/controllers/cart.controller.js
@@ -99,6 +99,13 @@ const CartController = {
             res.json(cart);
         } catch (e) { res.status(400).json({ error: e.message }); }
     },
+
+    async checkout(req, res) {
+        try {
+            const order = await CartService.checkout(req.params.id, req.body);
+            res.status(201).json(order);
+        } catch (e) { res.status(400).json({ error: e.message }); }
+    },
 };
 
 module.exports = CartController;

--- a/src/routes/cart-routes.js
+++ b/src/routes/cart-routes.js
@@ -30,4 +30,7 @@ router.post('/carts/:id/override-totals', CartController.overrideTotals); // bod
 router.patch('/carts/:id/status', CartController.setStatus);              // body: { status }
 router.patch('/carts/:id/metadata', CartController.setMetadata);          // body: { metadata }
 
+// Checkout
+router.post('/carts/:id/checkout', CartController.checkout);             // body: { metadata? }
+
 module.exports = router;

--- a/src/services/cart.service.js
+++ b/src/services/cart.service.js
@@ -2,6 +2,7 @@
 const db = require('../models');
 const { sequelize, Sequelize, Cart, CartItem, Customer, Address, ProductVariant } = db;
 const { Op } = Sequelize;
+const OrderService = require('./order.service');
 
 /**
  * Тэмдэглэл:
@@ -185,6 +186,10 @@ const CartService = {
         if (!cart) throw new Error('Cart not found');
         await cart.update({ metadata });
         return this.getCartById(cart_id);
+    },
+
+    async checkout(cart_id, { metadata } = {}) {
+        return await OrderService.createFromCart(cart_id, { metadata });
     },
 };
 


### PR DESCRIPTION
## Summary
- allow carts to be checked out by creating orders via new CartService.checkout
- expose checkout through CartController and `/carts/:id/checkout` route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac412f3e40832a94714bbd2d14c660